### PR TITLE
feat(pagina): Pagina para tratamientos

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,10 +1,12 @@
 import { Routes } from '@angular/router';
 import { HomeLayoutComponent } from './main/layouts/home-layout/home-layout.component';
 import { HomeComponent } from './main/pages/home/home.component';
+import { TreatmentsComponent } from './main/pages/treatments/treatments.component';
 
 export const routes: Routes = [
     { path: '', redirectTo: 'home', pathMatch: 'full' },
     {path: 'home', component: HomeLayoutComponent, title: 'Clinica Dental Villegas', children: [
-        {path: '', component: HomeComponent, title: 'Clinica Dental Villegas'}
+        {path: '', component: HomeComponent, title: 'Clinica Dental Villegas'},
+        {path: 'treatments', component: TreatmentsComponent, title: 'Tratamientos | Clinica Dental Villegas'}
     ]}
 ];

--- a/src/app/main/components/treatment-card/treatment-card.component.spec.ts
+++ b/src/app/main/components/treatment-card/treatment-card.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TreatmentCardComponent } from './treatment-card.component';
+
+describe('TreatmentCardComponent', () => {
+  let component: TreatmentCardComponent;
+  let fixture: ComponentFixture<TreatmentCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TreatmentCardComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(TreatmentCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/main/components/treatment-card/treatment-card.component.ts
+++ b/src/app/main/components/treatment-card/treatment-card.component.ts
@@ -1,0 +1,70 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-treatment-card',
+  standalone: true,
+  imports: [],
+  template: `
+    <div class="card-container rounded-4 p-3 p-md-4 mb-4">
+      <div class="row g-4 align-items-center">
+        <div class="col-lg-6 order-lg-1 order-2">
+          <h2 class="text-blue-light mb-3">{{ treatmentType().title }}</h2>
+          <p class="text-white mb-3">{{ treatmentType().description }}</p>
+          <ul class="text-white list-unstyled row">
+            @for (treatment of treatmentType().treatments; track $index) {
+              <li class="col-md-6 mb-2">
+                <i class="bi bi-check-circle-fill text-blue-light me-2"></i>
+                {{ treatment }}
+              </li>
+            }
+          </ul>
+        </div>
+        <div class="col-lg-6 order-lg-2 order-1">
+          <div class="treatment-image-container">
+            <img 
+              class="img-fluid rounded-3 w-100 h-auto" 
+              [src]="treatmentType().imagePath" 
+              [alt]="'Imagen de ' + treatmentType().title"
+              loading="lazy"
+            >
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .card-container {
+      background-color: var(--blue-color);
+      width: 100%;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    
+    .text-blue-light {
+      color: var(--blue-color-light);
+    }
+    
+    .treatment-image-container {
+      height: 100%;
+      min-height: 250px;
+      display: flex;
+      align-items: center;
+    }
+    
+    @media (min-width: 992px) {
+      .treatment-image-container {
+        min-height: 300px;
+      }
+    }
+  `]
+})
+export class TreatmentCardComponent {
+  treatmentType = input.required<TreatmentType>();
+}
+
+export interface TreatmentType {
+  title: string;
+  description: string;
+  treatments: string[];
+  imagePath: string;
+}

--- a/src/app/main/layouts/home-layout/home-layout.component.ts
+++ b/src/app/main/layouts/home-layout/home-layout.component.ts
@@ -14,7 +14,7 @@ import { RouterOutlet } from '@angular/router';
 export class HomeLayoutComponent {
   navItems: NavItem[] = [
     {name: 'Inicio', link: 'home'},
-    {name: 'Tratamientos', link: 'tratamientos'},
+    {name: 'Tratamientos', link: 'home/treatments'},
     {name: 'Blog', link: 'blog'},
     {name: 'Contactos', link: '#contactos'},
   ]

--- a/src/app/main/pages/treatments/treatments.component.html
+++ b/src/app/main/pages/treatments/treatments.component.html
@@ -1,1 +1,5 @@
-<p>treatments works!</p>
+<section class="container-fluid">
+    @for (treatmentType of treatmentTypes; track $index) {
+        <app-treatment-card class="d-flex justify-content-center" [treatmentType]="treatmentType"></app-treatment-card>
+    }
+</section>

--- a/src/app/main/pages/treatments/treatments.component.ts
+++ b/src/app/main/pages/treatments/treatments.component.ts
@@ -1,11 +1,71 @@
 import { Component } from '@angular/core';
+import { TreatmentCardComponent, TreatmentType } from "../../components/treatment-card/treatment-card.component";
 
 @Component({
   selector: 'app-treatments',
-  imports: [],
+  imports: [TreatmentCardComponent],
   templateUrl: './treatments.component.html',
   styleUrl: './treatments.component.css'
 })
 export class TreatmentsComponent {
 
+  treatmentTypes: TreatmentType[] = [
+  {
+    title: 'Ortodoncia',
+    description: `
+      Esta especialidad tiene como fin el diagnóstico y tratamiento de las alteraciones 
+      de la posición de los dientes y/o huesos maxilares. Por lo general, el tratamiento 
+      implica la colocación de brackets y alambres delgados que tienen la función de alinear 
+      los dientes y ajustar la mordida de manera ideal.
+    `,
+    treatments: [
+      'Maloclusión I.II y III',
+      'Brackets estéticos',
+      'Brackets metálicos',
+      'Brackets Lingual'
+    ],
+    imagePath: 'media/tipoortodoncia.jpg'
+  },
+  {
+    title: 'Endodoncia',
+    description: `
+      Cuando la parte viva interna del cliente ha sido infectada a causa de caries profundas, el tratamiento de
+      endodoncia implica limpiar y sellar los conductos dentales para salvar la pieza afectada. Luego es posible
+      reconstruir la porción externa del diente.
+    `,
+    treatments: [
+      'Endodoncia molares',
+      'Retratamiento de endodoncias'
+    ],
+    imagePath: 'media/endodoncia-multirradicular.jpg'
+  },
+  {
+    title: 'Cirugías',
+    description: `
+      Estas intervenciones son realizadas por cirujanos orales o maxilofaciales, profesionales especializados en el
+      diagnóstico y tratamiento de afecciones que no pueden ser resueltas con tratamientos convencionales.
+    `,
+    treatments: [
+      'Bichectomias',
+      'Frenilectomias',
+      'Muelas del jucio/cordales',
+      'Supernumerario'
+    ],
+    imagePath: 'media/cirugiadental.jpg'
+  },
+  {
+    title: 'Estética Dental',
+    description: `
+      Es una especialidad de la odontología que soluciona problemas relacionados con la salud bucal y la armonía
+      estética de la boca en su totalidad.
+    `,
+    treatments: [
+      'Diseño de sonrisa',
+      'Carillas de zirconio',
+      'Carillas de disilicato de litio',
+      'Carillas con resina'
+    ],
+    imagePath: 'media/esteticadental2.jpg'
+  }
+]
 }


### PR DESCRIPTION
Se crea y configura la página para exhibir los tratamientos, se construyen las rutas, se crean las tarjetas reutilizables de los tipos de tratamiento. Esto permitirá seguir avanzando con el módulo de la pagina principal agrupada en la carpeta main del proyecto.